### PR TITLE
feat : 카카오 OAuth 개발

### DIFF
--- a/src/main/java/honbob/honbob/config/PasswordEncoderConfig.java
+++ b/src/main/java/honbob/honbob/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package honbob.honbob.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/honbob/honbob/config/WebClientConfig.java
+++ b/src/main/java/honbob/honbob/config/WebClientConfig.java
@@ -1,0 +1,39 @@
+
+package honbob.honbob.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        // 메모리 버퍼 크기 설정 (기본값은 256KB)
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024 * 10)) // 10MB
+                .build();
+
+        // 타임아웃 설정 (연결 및 응답 타임아웃)
+        HttpClient httpClient = HttpClient.create(ConnectionProvider.create("honbob-provider"))
+                .responseTimeout(Duration.ofSeconds(10));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(exchangeStrategies)
+                .build();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/honbob/honbob/controller/KakaoLoginController.java
+++ b/src/main/java/honbob/honbob/controller/KakaoLoginController.java
@@ -1,0 +1,93 @@
+package honbob.honbob.controller;
+
+import honbob.honbob.dto.UserLoginResponse;
+import honbob.honbob.global.exception.BusinessException;
+import honbob.honbob.global.exception.ExceptionType;
+import honbob.honbob.global.response.ResponseBody;
+import honbob.honbob.global.response.ResponseUtil;
+import honbob.honbob.service.kakao.KakaoTokenService;
+import honbob.honbob.service.kakao.LoginService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoLoginController {
+    private final LoginService loginService;
+    private final KakaoTokenService kakaoTokenService;
+
+    /**
+     * 카카오 로그인 페이지로 리다이렉트
+     */
+    @GetMapping("/api/auth/kakao/login")
+    public ResponseEntity<ResponseBody<Map<String, String>>> getKakaoLoginUrl() {
+        log.info("카카오 로그인 URL 요청");
+        String loginUrl = loginService.getKakaoLoginUrl();
+
+        Map<String, String> response = new HashMap<>();
+        response.put("loginUrl", loginUrl);
+
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
+    }
+
+
+    /**
+     * 카카오 로그인 콜백 처리
+     * 인가 코드로 카카오 토큰을 요청하고 사용자 정보를 가져옴
+     */
+    @GetMapping("/auth/login/kakao")
+    public void kakaoLoginCallback(
+            @RequestParam("code") String code,
+            HttpServletResponse response
+    ) throws IOException {
+        if (!StringUtils.hasText(code)) {
+            throw new BusinessException(ExceptionType.KAKAO_CODE_MISSING);
+        }
+        // code로 카카오 토큰 및 유저 정보 처리
+        UserLoginResponse loginResult = kakaoTokenService.processKakaoLoginWithCode(code);
+        log.info("result={}",loginResult);
+        // 앱 딥링크 URL 생성 (스킴은 앱에 맞게 수정)
+        String deepLink = String.format(
+                "exp://172.30.203.135:8081/?accessToken=%s&refreshToken=%s&nickname=%s&profileImageUrl=%s&isNewMember=%s",
+                URLEncoder.encode(loginResult.getAccessToken(), StandardCharsets.UTF_8),
+                URLEncoder.encode(loginResult.getRefreshToken(), StandardCharsets.UTF_8),
+                URLEncoder.encode(loginResult.getNickname(), StandardCharsets.UTF_8),
+                URLEncoder.encode(loginResult.getProfileImageUrl(), StandardCharsets.UTF_8),
+                loginResult.isNewMember()
+        );
+        log.info("딥링크로 리다이렉트={}",deepLink);
+        // 앱 딥링크로 리다이렉트
+        response.sendRedirect(deepLink);
+    }
+
+
+    /**
+     * 액세스 토큰 갱신 (리프레시 토큰 사용)
+     */
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<ResponseBody<UserLoginResponse>> refreshToken(
+            @RequestParam("refreshToken") String refreshToken,
+            HttpServletResponse response) {
+
+        log.info("토큰 갱신 요청");
+
+        if (!StringUtils.hasText(refreshToken)) {
+            log.error("리프레시 토큰이 비어있습니다");
+            throw new BusinessException(ExceptionType.INVALID_TOKEN);
+        }
+        UserLoginResponse refreshResult = kakaoTokenService.refreshKakaoToken(refreshToken, response);
+        log.info("토큰 갱신 성공 - 사용자: {}", refreshResult.getNickname());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(refreshResult));
+    }
+}

--- a/src/main/java/honbob/honbob/domain/Member.java
+++ b/src/main/java/honbob/honbob/domain/Member.java
@@ -3,11 +3,13 @@ package honbob.honbob.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 public class Member {
 
@@ -17,14 +19,21 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
-    @Column(nullable = false)
+
     private String profileImage;
+
+    // 카카오 관련 필드 추가
+    @Column(unique = true)
+    private Long kakaoId;
+
+    @Column
+    private String refreshToken;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Recipe> recipeList;
@@ -37,4 +46,16 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<UserIngredient> userIngredientList;
+
+    // 카카오 회원 생성 메서드
+    public static Member createKakaoMember(Long kakaoId, String name, String email, String profileImage, String refreshToken) {
+        Member member = new Member();
+        member.setKakaoId(kakaoId);
+        member.setName(name);
+        member.setEmail(email);
+        member.setProfileImage(profileImage);
+        member.setRefreshToken(refreshToken);
+        member.setPassword(""); // 소셜 로그인은 비밀번호가 없음
+        return member;
+    }
 }

--- a/src/main/java/honbob/honbob/dto/KakaoLoginRequest.java
+++ b/src/main/java/honbob/honbob/dto/KakaoLoginRequest.java
@@ -1,0 +1,10 @@
+package honbob.honbob.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoLoginRequest {
+    private String code;
+}

--- a/src/main/java/honbob/honbob/dto/KakaoTokenDto.java
+++ b/src/main/java/honbob/honbob/dto/KakaoTokenDto.java
@@ -1,0 +1,25 @@
+package honbob.honbob.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoTokenDto {
+    
+    @JsonProperty("access_token")
+    private String accessToken;
+    
+    @JsonProperty("token_type")
+    private String tokenType;
+    
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+    
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+}

--- a/src/main/java/honbob/honbob/dto/KakaoUserInfoDto.java
+++ b/src/main/java/honbob/honbob/dto/KakaoUserInfoDto.java
@@ -1,0 +1,46 @@
+package honbob.honbob.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class KakaoUserInfoDto {
+
+    private Long id;
+    private String nickname;
+    private String email;
+    private String profileImageUrl;
+
+    @JsonProperty("kakao_account")
+    private void unpackKakaoAccount(Map<String, Object> kakaoAccount) {
+        if (kakaoAccount == null) return;
+
+        // 이메일 추출
+        this.email = (String) kakaoAccount.get("email");
+
+        // 프로필 정보 추출
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        if (profile != null) {
+            this.nickname = (String) profile.get("nickname");
+            this.profileImageUrl = (String) profile.get("profile_image_url");
+        }
+    }
+
+    @JsonProperty("properties")
+    private void unpackProperties(Map<String, Object> properties) {
+        if (properties == null) return;
+
+        // 기본 정보가 없을 경우를 대비해 properties에서도 추출
+        if (this.nickname == null) {
+            this.nickname = (String) properties.get("nickname");
+        }
+
+        if (this.profileImageUrl == null) {
+            this.profileImageUrl = (String) properties.get("profile_image");
+        }
+    }
+}

--- a/src/main/java/honbob/honbob/dto/UserLoginResponse.java
+++ b/src/main/java/honbob/honbob/dto/UserLoginResponse.java
@@ -1,0 +1,43 @@
+package honbob.honbob.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 값은 JSON으로 변환하지 않음
+public class UserLoginResponse {
+    private String message;
+    private String accessToken;  // JWT 토큰
+    private String refreshToken; // 카카오 리프레시 토큰 (선택적)
+    private String nickname;
+    private String profileImageUrl;
+    private boolean isNewMember;
+
+    // 기존 생성자 호환을 위한 팩토리 메서드
+    public static UserLoginResponse of(String message, String accessToken, String nickname,
+                                       String profileImageUrl, boolean isNewMember) {
+        return UserLoginResponse.builder()
+                .message(message)
+                .accessToken(accessToken)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .isNewMember(isNewMember)
+                .build();
+    }
+
+    // 리프레시 토큰 포함 버전
+    public static UserLoginResponse withRefreshToken(String message, String accessToken,
+                                                     String refreshToken, String nickname,
+                                                     String profileImageUrl, boolean isNewMember) {
+        return UserLoginResponse.builder()
+                .message(message)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .isNewMember(isNewMember)
+                .build();
+    }
+}

--- a/src/main/java/honbob/honbob/repository/MemberRepository.java
+++ b/src/main/java/honbob/honbob/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package honbob.honbob.repository;
+
+import honbob.honbob.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByKakaoId(Long kakaoId);
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/honbob/honbob/service/kakao/KakaoTokenService.java
+++ b/src/main/java/honbob/honbob/service/kakao/KakaoTokenService.java
@@ -1,0 +1,306 @@
+package honbob.honbob.service.kakao;
+
+import honbob.honbob.domain.Member;
+import honbob.honbob.dto.KakaoTokenDto;
+import honbob.honbob.dto.KakaoUserInfoDto;
+import honbob.honbob.dto.UserLoginResponse;
+import honbob.honbob.global.exception.BusinessException;
+import honbob.honbob.global.exception.ExceptionType;
+import honbob.honbob.repository.MemberRepository;
+import honbob.honbob.service.member.MemberService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoTokenService {
+
+    private final WebClient webClient;
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    /**
+     * 카카오 토큰 요청 (인가 코드를 이용)
+     */
+    private KakaoTokenDto requestKakaoToken(String code) {
+        log.info("카카오 토큰 요청 - 인가 코드: {}", code);
+
+        try {
+            KakaoTokenDto tokenResponse = webClient.post()
+                    .uri("https://kauth.kakao.com/oauth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenDto.class)
+                    .block();
+
+            log.info("카카오 토큰 요청 성공");
+            return tokenResponse;
+        } catch (WebClientResponseException e) {
+            log.error("카카오 토큰 요청 실패 - 상태 코드: {}, 응답: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_REQUEST_FAILED);
+        } catch (Exception e) {
+            log.error("카카오 토큰 요청 중 예외 발생", e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+
+    /**
+     * 카카오 사용자 정보 요청 (액세스 토큰을 이용)
+     */
+    private KakaoUserInfoDto requestKakaoUserInfo(String accessToken) {
+        log.info("카카오 사용자 정보 요청");
+
+        KakaoUserInfoDto userInfoDto = webClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(KakaoUserInfoDto.class)
+                .block();
+
+        log.info("카카오 사용자 정보 요청 성공 - ID: {}, 닉네임: {}", userInfoDto.getId(), userInfoDto.getNickname());
+        return userInfoDto;
+    }
+
+    /**
+     * 리프레시 토큰을 쿠키에 저장
+     */
+    private void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 30); // 30일
+        response.addCookie(refreshTokenCookie);
+        log.info("리프레시 토큰 쿠키 설정 완료");
+    }
+
+    /**
+     * 카카오 로그인 프로세스 처리 (HttpServletResponse 없이 토큰만 처리)
+     * 인가 코드로 토큰을 받고, 사용자 정보를 조회하여 로그인/회원가입 처리
+     */
+    @Transactional
+    public UserLoginResponse processKakaoLoginWithCode(String code) {
+        try {
+            // 1. 인가 코드로 카카오 토큰 요청
+            KakaoTokenDto kakaoTokenDto = requestKakaoToken(code);
+
+            // 2. 액세스 토큰으로 사용자 정보 요청
+            KakaoUserInfoDto userInfoDto = requestKakaoUserInfo(kakaoTokenDto.getAccessToken());
+
+            // 3. 회원 가입 또는 로그인 처리
+            boolean isNewMember = !memberRepository.findByKakaoId(userInfoDto.getId()).isPresent();
+
+            Member member = memberService.processKakaoMember(
+                    userInfoDto.getId(),
+                    userInfoDto.getNickname(),
+                    userInfoDto.getEmail(),
+                    userInfoDto.getProfileImageUrl(),
+                    kakaoTokenDto.getRefreshToken()
+            );
+
+            // 4. JWT 토큰 생성
+            String jwtToken = memberService.createJwtToken(member);
+            log.info("jwtToken: {}", jwtToken);
+            // 5. 로그인 응답 생성 (클라이언트 응답용)
+            return UserLoginResponse.withRefreshToken(
+                    "로그인 성공",
+                    jwtToken,
+                    kakaoTokenDto.getRefreshToken(),
+                    userInfoDto.getNickname(),
+                    userInfoDto.getProfileImageUrl(),
+                    isNewMember
+            );
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 API 응답 오류: 상태 코드={}, 응답={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        } catch (Exception e) {
+            log.error("카카오 로그인 처리 중 오류 발생", e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        }
+    }
+
+    /**
+     * 카카오 로그인 프로세스 처리 (기존 메서드 - 쿠키 설정 포함)
+     * 인가 코드로 토큰을 받고, 사용자 정보를 조회하여 로그인/회원가입 처리
+     */
+    @Transactional
+    public UserLoginResponse processKakaoLogin(String code, HttpServletResponse response) {
+        try {
+            // 1. 인가 코드로 카카오 토큰 요청
+            KakaoTokenDto kakaoTokenDto = requestKakaoToken(code);
+
+            // 2. 액세스 토큰으로 사용자 정보 요청
+            KakaoUserInfoDto userInfoDto = requestKakaoUserInfo(kakaoTokenDto.getAccessToken());
+
+            // 3. 회원 가입 또는 로그인 처리
+            boolean isNewMember = !memberRepository.findByKakaoId(userInfoDto.getId()).isPresent();
+
+            Member member = memberService.processKakaoMember(
+                    userInfoDto.getId(),
+                    userInfoDto.getNickname(),
+                    userInfoDto.getEmail(),
+                    userInfoDto.getProfileImageUrl(),
+                    kakaoTokenDto.getRefreshToken()
+            );
+
+            // 4. JWT 토큰 생성
+            String jwtToken = memberService.createJwtToken(member);
+
+            // 5. 리프레시 토큰을 쿠키에 저장
+            addRefreshTokenCookie(response, kakaoTokenDto.getRefreshToken());
+
+            // 6. 로그인 응답 생성 (클라이언트 응답용)
+            return UserLoginResponse.withRefreshToken(
+                    "로그인 성공",
+                    jwtToken,
+                    kakaoTokenDto.getRefreshToken(),
+                    userInfoDto.getNickname(),
+                    userInfoDto.getProfileImageUrl(),
+                    isNewMember
+            );
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 API 응답 오류: 상태 코드={}, 응답={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        } catch (Exception e) {
+            log.error("카카오 로그인 처리 중 오류 발생", e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        }
+    }
+
+    /**
+     * 액세스 토큰 갱신 (HttpServletResponse 없이 토큰만 처리)
+     */
+    @Transactional
+    public UserLoginResponse refreshKakaoTokenWithoutResponse(String refreshToken) {
+        try {
+            // 1. 리프레시 토큰으로 회원 조회
+            Member member = memberRepository.findByRefreshToken(refreshToken)
+                    .orElseThrow(() -> new BusinessException(ExceptionType.INVALID_TOKEN));
+
+            // 2. 카카오 토큰 갱신 요청
+            KakaoTokenDto newTokenDto = refreshKakaoToken(refreshToken);
+
+            // 3. 회원 정보에 새 리프레시 토큰 저장
+            member.setRefreshToken(newTokenDto.getRefreshToken());
+            memberRepository.save(member);
+
+            // 4. JWT 토큰 생성
+            String jwtToken = memberService.createJwtToken(member);
+
+            // 5. 로그인 응답 생성
+            return UserLoginResponse.withRefreshToken(
+                    "토큰 갱신 성공",
+                    jwtToken,
+                    newTokenDto.getRefreshToken(),
+                    member.getName(),
+                    member.getProfileImage(),
+                    false
+            );
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 API 응답 오류: 상태 코드={}, 응답={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 갱신 중 오류 발생", e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        }
+    }
+
+    /**
+     * 카카오 토큰 갱신 (리프레시 토큰 사용)
+     */
+    private KakaoTokenDto refreshKakaoToken(String refreshToken) {
+        log.info("카카오 토큰 갱신 요청");
+
+        Map<String, String> formData = new HashMap<>();
+        formData.put("grant_type", "refresh_token");
+        formData.put("client_id", clientId);
+        formData.put("refresh_token", refreshToken);
+
+        KakaoTokenDto tokenDto = webClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue(formData)
+                .retrieve()
+                .bodyToMono(KakaoTokenDto.class)
+                .block();
+
+        log.info("카카오 토큰 갱신 성공");
+        return tokenDto;
+    }
+
+    /**
+     * 액세스 토큰 갱신 (기존 메서드 - 쿠키 설정 포함)
+     */
+    @Transactional
+    public UserLoginResponse refreshKakaoToken(String refreshToken, HttpServletResponse response) {
+        try {
+            // 1. 리프레시 토큰으로 회원 조회
+            Member member = memberRepository.findByRefreshToken(refreshToken)
+                    .orElseThrow(() -> new BusinessException(ExceptionType.INVALID_TOKEN));
+
+            // 2. 카카오 토큰 갱신 요청
+            KakaoTokenDto newTokenDto = refreshKakaoToken(refreshToken);
+
+            // 3. 회원 정보에 새 리프레시 토큰 저장
+            member.setRefreshToken(newTokenDto.getRefreshToken());
+            memberRepository.save(member);
+
+            // 4. JWT 토큰 생성
+            String jwtToken = memberService.createJwtToken(member);
+
+            // 5. 리프레시 토큰을 쿠키에 저장
+            addRefreshTokenCookie(response, newTokenDto.getRefreshToken());
+
+            // 6. 로그인 응답 생성
+            return UserLoginResponse.withRefreshToken(
+                    "토큰 갱신 성공",
+                    jwtToken,
+                    newTokenDto.getRefreshToken(),
+                    member.getName(),
+                    member.getProfileImage(),
+                    false
+            );
+
+        } catch (WebClientResponseException e) {
+            log.error("카카오 API 응답 오류: 상태 코드={}, 응답={}",
+                    e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 갱신 중 오류 발생", e);
+            throw new BusinessException(ExceptionType.KAKAO_TOKEN_ERROR);
+        }
+    }
+}

--- a/src/main/java/honbob/honbob/service/kakao/LoginService.java
+++ b/src/main/java/honbob/honbob/service/kakao/LoginService.java
@@ -1,0 +1,37 @@
+package honbob.honbob.service.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoginService {
+
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    /**
+     * 카카오 로그인 URL 생성
+     * @return 카카오 로그인 페이지 URL
+     */
+    public String getKakaoLoginUrl() {
+        log.debug("카카오 로그인 URL 생성 - clientId: {}, redirectUri: {}", clientId, redirectUri);
+
+        String url = "https://kauth.kakao.com/oauth/authorize"
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&response_type=code";
+
+        log.info("카카오 로그인 URL 생성 완료: {}", url);
+        return url;
+    }
+}

--- a/src/main/java/honbob/honbob/service/member/MemberService.java
+++ b/src/main/java/honbob/honbob/service/member/MemberService.java
@@ -1,0 +1,66 @@
+package honbob.honbob.service.member;
+
+import honbob.honbob.domain.Member;
+import honbob.honbob.global.exception.BusinessException;
+import honbob.honbob.global.exception.ExceptionType;
+import honbob.honbob.global.jwt.JwtUtil;
+import honbob.honbob.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public Member processKakaoMember(Long kakaoId, String nickname, String email, String profileImageUrl, String refreshToken) {
+        // 기존 카카오 ID로 회원 조회
+        return memberRepository.findByKakaoId(kakaoId)
+                .map(existingMember -> {
+                    // 기존 회원이면 정보 업데이트
+                    existingMember.setName(nickname);
+                    existingMember.setProfileImage(profileImageUrl);
+                    existingMember.setRefreshToken(refreshToken);
+                    log.info("기존 회원 정보 업데이트: {}", existingMember.getName());
+                    return existingMember;
+                })
+                .orElseGet(() -> {
+                    // 이메일로 회원 조회 (이메일 중복 확인)
+                    return memberRepository.findByEmail(email)
+                            .map(existingMember -> {
+                                // 이메일은 있지만 카카오 연동이 안된 회원인 경우
+                                existingMember.setKakaoId(kakaoId);
+                                existingMember.setName(nickname);
+                                existingMember.setProfileImage(profileImageUrl);
+                                existingMember.setRefreshToken(refreshToken);
+                                log.info("기존 이메일 회원에 카카오 연동: {}", existingMember.getName());
+                                return existingMember;
+                            })
+                            .orElseGet(() -> {
+                                // 신규 회원인 경우
+                                Member newMember = Member.createKakaoMember(
+                                        kakaoId, nickname, email, profileImageUrl, refreshToken);
+                                log.info("신규 회원 등록: {}", newMember.getName());
+                                return memberRepository.save(newMember);
+                            });
+                });
+    }
+
+    // JWT 토큰 생성
+    public String createJwtToken(Member member) {
+        return jwtUtil.generateToken(member.getId());
+    }
+
+    // 회원 ID로 회원 조회
+    @Transactional(readOnly = true)
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION


## 🚨관련 이슈
- #5 

## ✨ PR 요약

- 카카오 OAuth 구현

## 🔎 작업 상세
![image](https://github.com/user-attachments/assets/351355d5-756c-4551-b33f-f87f9847d439)

> /api/auth/kakao/login

- 사용자에게 카카오 로그인 URL을 반환합니다.
- clientId, redirectURI는 yml에 세팅된 환경변수를 사용합니다.

> /api/auth/kakao/login
- 사용자로부터 받은 인증코드를 이용하여 카카오 서버에 액세스 토큰을 요청합니다. 이때 액세스토큰, 리프레시 토큰을 발급받습니다.
- 액세스 토큰을 사용하여 카카오 서버로부터 사용자의 정보를 반환받고, 로그인 처리를 하여 사용자에게 Response를 반환합니다.
